### PR TITLE
handle more object key values

### DIFF
--- a/main.js
+++ b/main.js
@@ -165,8 +165,10 @@ const stringify = function (data, options) {
         }
 
         // wrap strange key with quotes
-        if (_item.key && !_item.key.match(/^\w[\d\w_]*$/)) {
-          _item.key = __quote(key, options.keyQuote || '"')
+        if (_item.key) {
+          if (_item.key.match(/^[^a-zA-Z]/) || _item.key.match(/[-'"\s]/)) {
+            _item.key = __quote(key, options.keyQuote || '"')
+          }
         }
         _out.push(options.endline + _spacing1 + _item.key + ':' + __keySpace + _item.value)
       }

--- a/main.js
+++ b/main.js
@@ -166,7 +166,7 @@ const stringify = function (data, options) {
 
         // wrap strange key with quotes
         if (_item.key) {
-          if (_item.key.match(/^[^a-zA-Z]/) || _item.key.match(/[-'"\s]/)) {
+          if (_item.key.match(/^[^a-zA-Z]/) || _item.key.match(/[-.'"\s]/)) {
             _item.key = __quote(key, options.keyQuote || '"')
           }
         }

--- a/test/tdd.js
+++ b/test/tdd.js
@@ -107,11 +107,12 @@ tap.test('stringify - object keys quoting', (test) => {
     "thunder": 0,
     "storm": 0,
     "thunder-storm": 0,
+    "thunder.storm": 0,
     'dquoted"key': 0,
     "squoted'key": 0
   }
   const options = {spacing: '', endline: ''}
-  const result = '{"1number":0,":colon":0," space":0,thunder:0,storm:0,"thunder-storm":0,"dquoted\\"key":0,"squoted\'key":0}'
+  const result = '{"1number":0,":colon":0," space":0,thunder:0,storm:0,"thunder-storm":0,"thunder.storm":0,"dquoted\\"key":0,"squoted\'key":0}'
   test.equal(stringify(data, options), result)
 })
 

--- a/test/tdd.js
+++ b/test/tdd.js
@@ -97,6 +97,25 @@ tap.test('stringify - basic data set, custom options', (test) => {
   test.equal(stringify(data, options), result)
 })
 
+tap.test('stringify - object keys quoting', (test) => {
+  test.plan(1)
+  const data = {
+    "1number": 0,
+    ":colon": 0,
+    " space": 0,
+    " space": 0,
+    "thunder": 0,
+    "storm": 0,
+    "thunder-storm": 0,
+    'dquoted"key': 0,
+    "squoted'key": 0
+  }
+  const options = {spacing: '', endline: ''}
+  const result = '{"1number":0,":colon":0," space":0,thunder:0,storm:0,"thunder-storm":0,"dquoted\\"key":0,"squoted\'key":0}'
+  test.equal(stringify(data, options), result)
+})
+
+
 tap.test('stringify - deferred type', (test) => {
   test.plan(1)
   const data = {a: stringify.deferred('my.enum.VALUE')}


### PR DESCRIPTION
```
var data = {
  "8k": null
}
```

was breaking. it was generating {8k: null} as output. changed to quote anytime the first character isn't alpha OR anytime the key contains a hyphen, quote, or whitespace