### PR TITLE
dont auto-discard on compress

### DIFF
--- a/main.js
+++ b/main.js
@@ -214,7 +214,7 @@ const stringify = function (data, options) {
   const __item = function (key, value, deep, path) {
     if (!deep) deep = 1
 
-    if ((options.discard || options.compress) && (value === undefined || value === null)) {
+    if ((options.discard) && (value === undefined || value === null)) {
       return null
     }
 

--- a/test/tdd.js
+++ b/test/tdd.js
@@ -387,7 +387,7 @@ tap.test('stringify - use options.compress', (test) => {
     spacing: '',
     endline: ''
   }
-  const result = '{a:new Date(1418187600000),b:Buffer.from("YmFzZTY0LWlhbWdl"),c:function freakyfib(r){for(var f,n=1,a=0;r>=0;)f=n,n+=a,a=f,r--;return a}}'
+  const result = '{a:new Date(1418187600000),b:Buffer.from("YmFzZTY0LWlhbWdl"),c:function freakyfib(r){for(var f,n=1,a=0;r>=0;)f=n,n+=a,a=f,r--;return a},f:null,g:undefined}'
   test.equal(stringify(data, options), result)
 })
 


### PR DESCRIPTION
I had a use case where I want to compress, but I want to keep null/undefined values (the existence of the keys is important).  Seemed reasonable to give users the choice to do compress but not discard.